### PR TITLE
Update lifters.csv

### DIFF
--- a/meet-data/usapl/WA-2014-02/lifters.csv
+++ b/meet-data/usapl/WA-2014-02/lifters.csv
@@ -37,7 +37,7 @@ DQ,F,Aaliyah Gray,B,R-T1,48,Raw,46.9,,,,
 1,M,Kevin Greene,SBD,R-JR,75,Raw,74.6,170,100,170,440
 1,M,Eric Wuthrich,SBD,R-JR,82.5,Raw,76.7,140,100,180,420
 1,M,Sun Ly,SBD,R-JR,90,Raw,86.4,182.5,135,205,522.5
-1,M,Andrew Pears,SBD,R-JR,100,Raw,95.5,242.5,275,292.5,810
+1,M,Andrew Pears,SBD,R-JR,100,Single-ply,95.5,242.5,275,292.5,810
 2,M,Pierce Frandle,SBD,R-JR,100,Raw,96.4,170,120,227.5,517.5
 1,M,Marek Czaja,SBD,R-O,67.5,Raw,65.7,107.5,77.5,202.5,387.5
 2,M,Andrew Waite,SBD,R-O,67.5,Raw,65.2,115,82.5,167.5,365


### PR DESCRIPTION
Changed Andrew Pears from Raw to single ply, as with other bench press edits I have made, were this actually a raw lift it would give him an all time Raw world record but no such record exists in the USAPL records database.  Likely a simple notation error.