### PR TITLE
Update lifters.csv

### DIFF
--- a/meet-data/apf/1101/lifters.csv
+++ b/meet-data/apf/1101/lifters.csv
@@ -1,4 +1,4 @@
-Name,Age,Division,WeightClassKg,BestSquatKg,BestBenchKg,BestDeadliftKg,TotalKg,Place,Sex,Event,Equipment
+Name,Age,Division,WeightClassKg,BestSquatKg,BestBenchKg,BestDeadliftKg,TotalKg,Place,Sex,Event,Equipment,BodyweightKg
 Emily Simpson,20,F-AAJun,60,120.20,74.84,92.99,288.03,1,F,SBD,Multi-ply
 Kayla Palmberg,20,F-Ajun,67.5,145.15,102.06,136.08,383.29,1,F,SBD,Multi-ply
 Margaret Kirkland,48,F-AAO,56,208.65,111.13,183.70,503.49,1,F,SBD,Multi-ply
@@ -57,7 +57,7 @@ Huguette Salahuddin,55,F-AAM4-R,100,120.20,49.90,131.54,301.64,1,F,SBD,Raw
 Susan Carrington,59,F-AAM4-R,60,52.16,31.75,70.31,154.22,1,F,SBD,Raw
 Jordan Masters,17,F-AAT2-R,67.5,77.11,43.09,95.25,215.46,1,F,SBD,Raw
 Jordan Masters,17,F-AT2-R,67.5,77.11,43.09,95.25,215.46,1,F,SBD,Raw
-April Mathis,24,F-AO-R,90+,278.96,188.24,263.08,730.28,1,F,SBD,Raw
+April Mathis,24,F-AO-R,90+,278.96,188.24,263.08,730.28,1,F,SBD,Raw,118.39
 Paulo Sevick,13,M-AT1-R,90,120.20,61.23,147.42,328.85,1,M,SBD,Raw
 Miguel Mattis,19,M-AT3-R,90,190.51,151.95,265.35,607.81,1,M,SBD,Raw
 Vincent Lysobey Jr,12,M-AAT1-R,67.5,70.31,43.09,70.31,183.70,1,M,SBD,Raw


### PR DESCRIPTION
Added BodyweightKg column in order to add a body-wight for April Mathis (in order to gain an approximate Wilks score and sort this result properly into the correct weight class.)  Her approximate weight was extrapolated from the average of the meet before (259 lb) and meet after (263 lb) to get a rough idea of her weight for this meet. (261 lb)