### PR TITLE
Update lifters.csv

### DIFF
--- a/meet-data/uspa/0135/lifters.csv
+++ b/meet-data/uspa/0135/lifters.csv
@@ -15,7 +15,7 @@ Place,Name,WeightClassKg,BodyweightKg,Age,Event,BestSquatKg,BestBenchKg,BestDead
 DQ,Juan Mendoza,90,85.77,26,SBD,,,,,M,Open,Raw,,
 DQ,Tim Masigat,110,105.87,33,SBD,190,,,,M,Open,Raw,,
 1,Joe Mass,140+,161.12,19,SBD,245,150,290,685,M,Open,Raw,,
-1,David Douglas,125,124.01,24,SBD,205,310,297.5,812.5,M,Open,Raw,,
+1,David Douglas,125,124.01,24,SBD,205,310,297.5,812.5,M,Open,Single-ply,,
 1,Athena McCanslish,67.5,61.87,43,B,,47.5,,47.5,F,Master 40-44,Raw,,
 1,Gary Witcher,125,121.02,41,B,,192.5,,192.5,M,Open,Raw,,
 1,Gary Witcher,125,121.02,41,B,,192.5,,192.5,M,Master 40-44,Raw,,


### PR DESCRIPTION
Changed David Douglas from Raw to single ply, the results.txt shows him in the single-ply division and his bench numbers would have otherwise been above the world record if his lifts were raw.