### PR TITLE
Update lifters.csv

### DIFF
--- a/meet-data/spf-archive/0503/lifters.csv
+++ b/meet-data/spf-archive/0503/lifters.csv
@@ -1,5 +1,5 @@
 Name,State,Equipment,Division,WeightClassKg,BodyweightKg,BestSquatKg,BestBenchKg,BestDeadliftKg,TotalKg,Event,Sex,Place
-Caitlin Holmstrom,MN,Raw,Open,90+,97.52,149.69,74.84,172.37,396.89,SBD,F,3
+Caitlin Holmstrom,MN,Wraps,Open,90+,97.52,149.69,74.84,172.37,396.89,SBD,F,3
 Anika Harper,NC,Raw,Submaster (33-39),90,87.27,136.08,45.36,142.88,324.32,SBD,F,1
 Chelsi Figley,OH,Raw,Submaster (33-39),67.5,62.96,,86.18,,86.18,B,F,1
 Cara Westin,CA,Multi-ply,Open,67.5,65.86,215.46,154.22,199.58,569.26,SBD,F,3
@@ -22,17 +22,17 @@ Michele Agostinelli,NY,Raw,Open,52,49.71,111.13,58.97,129.27,299.37,SBD,F,3
 Annie Fry,TN,Raw,Open,52,51.07,113.4,65.77,138.35,317.51,SBD,F,2
 Angela Adams,TN,Multi-ply,Masters (40-44),90+,113.04,,161.03,,161.03,B,F,1
 Tammy B Howard,VT,Multi-ply,Masters (45-49),67.5,67.22,183.7,140.61,149.69,474,SBD,F,1
-Beth Tarkany,OH,Raw,Open,90,88.36,199.58,95.25,208.65,503.49,SBD,F,3
-Kellyn Huehn,OH,Raw,Open,75,73.84,167.83,95.25,185.97,449.06,SBD,F,2
+Beth Tarkany,OH,Wraps,Open,90,88.36,199.58,95.25,208.65,503.49,SBD,F,3
+Kellyn Huehn,OH,Wraps,Open,75,73.84,167.83,95.25,185.97,449.06,SBD,F,2
 Marie Metcalf,KY,Raw,Masters (65+),90,88,102.06,52.16,117.93,272.16,SBD,F,1
-Sarah Cattan,KY,Raw,Open,75,74.84,199.58,72.57,183.7,455.86,SBD,F,1
+Sarah Cattan,KY,Wraps,Open,75,74.84,199.58,72.57,183.7,455.86,SBD,F,1
 Juli Cardasis,MI,Raw,Open,67.5,62.78,92.99,56.7,120.2,269.89,SBD,F,3
 Shelby Woten,NC,Raw,Junior (20-23),90+,114.12,147.42,61.23,142.88,351.53,SBD,F,1
-Ellen Stein,NY,Raw,Masters (60-64),60,59.87,179.17,83.91,176.9,439.98,SBD,F,1
+Ellen Stein,NY,Wraps,Masters (60-64),60,59.87,179.17,83.91,176.9,439.98,SBD,F,1
 Shelly Yates,NC,Raw,Masters (40-44),90,88.18,151.95,79.38,167.83,399.16,SBD,F,1
 Allison Hagan,KY,Raw,Masters (40-44),82.5,78.29,97.52,63.5,122.47,283.5,SBD,F,1
 Samantha Snowder,NC,Raw,Open,56,55.25,108.86,52.16,122.47,283.5,SBD,F,4
-Sabrina Provoast,MI,Raw,Open,90,89.81,185.97,108.86,215.46,510.29,SBD,F,2
+Sabrina Provoast,MI,Wraps,Open,90,89.81,185.97,108.86,215.46,510.29,SBD,F,2
 Melissa Byrd,NC,Raw,Open,52,51.89,86.18,38.56,124.74,249.48,SBD,F,5
 Melissa Byrd,NC,Raw,Masters (40-44),52,51.89,86.18,38.56,124.74,249.48,SBD,F,1
 Chanel Nolet,Canada,Multi-ply,Open,60,59.87,181.44,111.13,170.1,462.66,SBD,F,2
@@ -40,10 +40,10 @@ Kora Whitaker,KY,Raw,Junior (20-23),82.5,77.38,156.49,81.65,188.24,426.38,SBD,F,
 Amy Heise,OH,Raw,Submaster (33-39),90+,109.13,,43.09,99.79,142.88,BD,F,1
 Marianne Kosonen,,Multi-ply,Junior (20-23),52,51.98,210.92,108.86,163.29,483.08,SBD,F,1
 Chanael Warren,Pennsylvania,Raw,Open,90,89.54,138.35,58.97,149.69,347,SBD,F,5
-Amy Johnson,Florida,Raw,Open,90,87.54,215.46,106.59,210.92,532.97,SBD,F,1
+Amy Johnson,Florida,Wraps,Open,90,87.54,215.46,106.59,210.92,532.97,SBD,F,1
 Heidi Howar,OH,Multi-ply,Open,60,59.96,240.4,154.22,215.46,610.08,SBD,F,1
-Irina Petrovich,Belarus,Raw,Open,67.5,64.86,179.17,122.47,215.46,517.1,SBD,F,1
-Jeanine Whittaker,OH,Raw,Open,82.5,81.1,260.82,131.54,254.01,646.37,SBD,F,1
+Irina Petrovich,Belarus,Wraps,Open,67.5,64.86,179.17,122.47,215.46,517.1,SBD,F,1
+Jeanine Whittaker,OH,Wraps,Open,82.5,81.1,260.82,131.54,254.01,646.37,SBD,F,1
 Darlene Delk,MI,Raw,Open,82.5,80.74,127.01,58.97,145.15,331.12,SBD,F,5
 Tabitha Reynolds,CA,Multi-ply,Open,67.5,65.14,151.95,68.04,147.42,367.41,SBD,F,4
 Debbie Damminga,MN,Multi-ply,Open,75,73.39,235.87,115.67,226.8,578.33,SBD,F,1
@@ -54,10 +54,10 @@ Sue Priver,MA,Raw,Masters (40-44),90+,120.56,86.18,61.23,176.9,324.32,SBD,F,2
 Baylee Meyer,OH,Raw,Teenage (13-19),67.5,65.5,,40.82,,40.82,B,F,1
 Elisha Santucci,TN,Raw,Junior (20-23),67.5,65.41,142.88,81.65,149.69,374.21,SBD,F,1
 Melissa Stevens,OH,Multi-ply,Open,56,55.97,195.04,122.47,167.83,485.34,SBD,F,1
-Shana Miller,KY,Raw,Open,52,50.89,163.29,95.25,156.49,415.04,SBD,F,1
-Lauren Huffman,SC,Raw,Open,90,88.63,219.99,,,,SBD,F,DQ
+Shana Miller,KY,Wraps,Open,52,50.89,163.29,95.25,156.49,415.04,SBD,F,1
+Lauren Huffman,SC,Wraps,Open,90,88.63,219.99,,,,SBD,F,DQ
 Alison Crowdus,KY,Multi-ply,Open,90+,104.05,213.19,158.76,199.58,571.53,SBD,F,1
-Jennifer Millican,TN,Raw,Open,56,55.34,190.51,97.52,190.51,478.54,SBD,F,1
+Jennifer Millican,TN,Wraps,Open,56,55.34,190.51,97.52,190.51,478.54,SBD,F,1
 Vikki Traugot,TN,Multi-ply,Open,67.5,64.23,,,,,SBD,F,DQ
 Jenae Pavlak,MN,Raw,Open,82.5,81.92,161.03,97.52,158.76,417.3,SBD,F,2
 Kimberly Lynch,OH,Raw,Junior (20-23),60,57.15,,,140.61,140.61,D,F,1


### PR DESCRIPTION
Changed shana miller, jen millican, ellen stein, sarah cattan, jenine whittaker, laura hauffman, Beth Tarkany, amy johnson, Irina Petrovich, Kellyn Huehn, Caitlin Holmstrom and Sabrina Provoast from Raw to Wraps.
Looks like some of the girls in the 2016 SPF Women;s Pro AM are miss-assigned raw when they were in wraps a few of their squats results are inordinately high I don't know for sure how many were miss labeled, but these one were the ones that stuck out most (based on prior performance and compared to current raw without wraps squat records).
Actually a pretty good video here with bio cards that helped me confirm that these lifters were in wraps: https://www.youtube.com/watch?v=WityO2AEpxM