### PR TITLE
Update lifters.csv

### DIFF
--- a/meet-data/cpu/2015-12-18-75b134a7/lifters.csv
+++ b/meet-data/cpu/2015-12-18-75b134a7/lifters.csv
@@ -63,7 +63,7 @@ SBD,M,Vince Green,MB,102.6,105,Master 1,230.0,170.0,240.0,640.0,Raw,1
 SBD,M,Kristers Sauka,AB,92.3,93,Junior,250.0,165.0,255.0,670.0,Raw,1
 SBD,M,Dustin Fraser,SK,90.7,93,Junior,190.0,117.5,230.0,537.5,Raw,3
 SBD,M,Cameron Jones,SK,90.9,93,Junior,212.5,132.5,260.0,605.0,Raw,2
-SBD,F,Hailey Kostyniuk,MB,129.4,84+,Junior,235.0,97.5,215.0,547.5,Raw,1
+SBD,F,Hailey Kostynuik,MB,129.4,84+,Junior,235.0,97.5,215.0,547.5,Raw,1
 SBD,F,Hannah Brock,SK,81.7,84,Junior,120.0,62.5,130.0,312.5,Raw,2
 SBD,F,Ariel Chessall,AB,78.7,84,Junior,127.5,65.0,132.5,325.0,Raw,1
 SBD,M,Ahmad Eid,AB,82.4,83,Junior,207.5,122.5,240.0,570.0,Raw,2


### PR DESCRIPTION
reversed the "iu" to "ui" in Hailey's last name, a simple spelling error on these two meets, her Instagram shows it spelled Kostynuik.