### PR TITLE
Update lifters.csv

### DIFF
--- a/meet-data/cpu/2014-02-16-2614b02d/lifters.csv
+++ b/meet-data/cpu/2014-02-16-2614b02d/lifters.csv
@@ -17,7 +17,7 @@ SBD,M,Devin LaFerriere,MB,96.2,105,Open,152.5,107.5,207.5,467.5,Raw,4
 SBD,M,Brent Wasylowski,MB,98.2,105,Open,225.0,150.0,322.5,697.5,Raw,1
 SBD,F,Janet Loesel Sitar,MB,81.3,84,Master 1,80.0,55.0,115.0,250.0,Raw,1
 SBD,M,Scott Downs,MB,90.2,93,Junior,195.0,110.0,272.5,577.5,Raw,1
-SBD,F,Hailey Kostyniuk,MB,117.4,84+,Junior,130.0,85.0,152.5,367.5,Raw,1
+SBD,F,Hailey Kostynuik,MB,117.4,84+,Junior,130.0,85.0,152.5,367.5,Raw,1
 SBD,M,Jules Esteban,MB,82.7,83,Junior,185.0,102.5,205.0,492.5,Raw,1
 SBD,M,Trent Monk,MB,73.1,74,Junior,120.0,102.5,185.0,407.5,Raw,1
 SBD,M,Kyle Thompson,MB,98.3,105,Junior,165.0,120.0,205.0,490.0,Raw,2


### PR DESCRIPTION
reversed the "iu" to "ui" in Hailey's last name, a simple spelling error on these two meets, her Instagram shows it spelled Kostynuik.