### PR TITLE
Update name-corrections.dat

### DIFF
--- a/lifter-data/name-corrections.dat
+++ b/lifter-data/name-corrections.dat
@@ -607,3 +607,12 @@ Anthony Oliveira,Anthony Oliverra,Anthony Olivera,Anthony Oliveria,Anthony Olivi
 Adam Nagele,Adam E Nagele,A. Nagele
 Ryan Nagele,R. Nagele
 Glen Pfleegor Jr,Glen A. Pfleegor Jr,Glenn Pfleegor
+Yulia Shenkarenko,Yuliya Shenkarenko
+Matt Sohmer,Matthew Sohmer
+Phillip Brewer,Philip Brewer
+Oleg Bazilevich,Oleg Bazlevych
+LeRoy Walker,Leroy Walker
+Stuart Jamieson,Jamieson Stuart
+Richard Hawthorne,Richard Hawthrone
+Mikhail Shivlyakov,Mikhail Shivlayakov
+Shorty Sadang,Bienvenido Sadang


### PR DESCRIPTION
Most of these are simple spelling errors, Matt Sohmer goes by Matt not Matthew on his Instagram so I went with that.  As for Shorty, his real name is Bienvenido, but he hasn't used it in a contest registration since 2014 and anywhere you can find him online he goes as Shorty so that name makes most sense.