### PR TITLE
Update name-corrections.dat

### DIFF
--- a/lifter-data/name-corrections.dat
+++ b/lifter-data/name-corrections.dat
@@ -622,3 +622,4 @@ Charles Galasso,Charlie Galasso
 TJ Dunsmoor,T.J. Dunsmoor,T J Dunsmoor
 Caterine González,Caterine Gonzalez
 Nyrel Allen,Nyrel SC Allen
+Mike Farr,Michael Farr


### PR DESCRIPTION
This fix is for Mike Farr (Silent Mike) his Instagram doesn't specify weather he goes by Mike or Michael, as he typically is called Silent Mike these days, but his most recent meet he registered as Mike and Mike is part of "Silent Mike" so I figure that's the best one to go with...