### PR TITLE
Update lifters.csv

### DIFF
--- a/meet-data/spf-archive/0415/lifters.csv
+++ b/meet-data/spf-archive/0415/lifters.csv
@@ -4,7 +4,7 @@ B,Carlos Flores,M,Raw,Masters 40-44,90,,185,,185,1
 B,Tiny Meeker,M,Multi-ply,Masters 40-44,140+,,,,,DQ
 SBD,Bobby Morgan,M,Wraps,Masters 40-44,75,220,170,250,640,1
 SBD,Simon Simones,M,Wraps,Masters 40-44,82.5,165,140,207.5,512.5,1
-B,Rene Garanta,M,Raw,Masters 45-49,53,,197.5,,197.5,1
+B,Rene Garanta,M,Raw,Masters 45-49,117.5,,197.5,,197.5,1
 SBD,Kyde Eddleman,M,Wraps,Masters 50-54,117.5,215,165,230,610,1
 B,Russell Richter,M,Raw,Masters 50-54,100,,180,,180,1
 B,Eric Doublin,M,Single-ply,Masters 50-54,125,,307.5,,307.5,1


### PR DESCRIPTION
According to the results data attached to this meet: https://github.com/sstangl/openpowerlifting/blob/master/meet-data/spf-archive/0415/results.csv , Rene Garanta is in the 259 lb (117.5 kg) class, not the 53 kg class.