### PR TITLE
Update lifters.csv

### DIFF
--- a/meet-data/rps/1733/lifters.csv
+++ b/meet-data/rps/1733/lifters.csv
@@ -41,15 +41,15 @@ M,Wraps,Pro Open,100,Matthew Karbowski,99.61,250,165,275,690,SBD,2
 M,Wraps,Pro Open,100,Andrew O'Dell,97.98,235,167.5,272.5,675,SBD,3
 M,Wraps,Pro Open,100,Julio Serrano,98.25,332.5,172.5,337.5,842.5,SBD,1
 M,Multi-ply,Pro Master 50-54,100,Rob Schmidt,98.79,285,192.5,255,732.5,SBD,1
-M,Raw,Amateur Open,110,Justin Haskins,107.95,155,250,250,655,SBD,1
-M,Wraps,Pro Teen 18-19,110,Grant Brubaker,109.68,132.5,225,225,582.5,SBD,1
-M,Wraps,Pro Open,110,Ryan Kennedy,106.05,145,222.5,222.5,590,SBD,2
-M,Wraps,Amateur Open,110,Sam Tefft,106.96,187.5,245,245,677.5,SBD,1
-M,Wraps,Pro Open,110,Anthony Diaz,108.32,167.5,297.5,297.5,762.5,SBD,1
-M,Wraps,Pro Open,125,Ryan Conley,114.31,197.5,287.5,287.5,772.5,SBD,1
-M,Raw,Pro Open,125,Andy Polk,117.93,160,307.5,307.5,775,SBD,1
-M,Wraps,Amateur Open,140,Lucas Vogel,129.18,165,250,250,665,SBD,1
-M,Wraps,Pro Open,140+,Andrew Olaya,149.69,175,287.5,287.5,750,SBD,1
+M,Raw,Amateur Open,110,Justin Haskins,107.95,,155,250,405,SBD,1
+M,Wraps,Pro Teen 18-19,110,Grant Brubaker,109.68,,132.5,225,357.5,SBD,1
+M,Wraps,Pro Open,110,Ryan Kennedy,106.05,,145,222.5,367.5,SBD,2
+M,Wraps,Amateur Open,110,Sam Tefft,106.96,,187.5,245,432.5,SBD,1
+M,Wraps,Pro Open,110,Anthony Diaz,108.32,,167.5,297.5,465,SBD,1
+M,Wraps,Pro Open,125,Ryan Conley,114.31,,197.5,287.5,485,SBD,1
+M,Raw,Pro Open,125,Andy Polk,117.93,,160,307.5,467.5,SBD,1
+M,Wraps,Amateur Open,140,Lucas Vogel,129.18,,165,250,415,SBD,1
+M,Wraps,Pro Open,140+,Andrew Olaya,149.69,,175,287.5,462.5,SBD,1
 F,Raw,Amateur Master 70-74,60,Judith Reed,59.87,,57.5,92.5,150,BD,1
 F,Raw,Pro Master 40-44,56,Miriam Rojas,55.34,,47.5,100,147.5,BD,1
 M,Raw,Pro Teen 18-19,82.5,Kasey Kaufmann,75.84,,112.5,185,297.5,BD,1

--- a/meet-data/rps/1733/lifters.csv
+++ b/meet-data/rps/1733/lifters.csv
@@ -41,15 +41,15 @@ M,Wraps,Pro Open,100,Matthew Karbowski,99.61,250,165,275,690,SBD,2
 M,Wraps,Pro Open,100,Andrew O'Dell,97.98,235,167.5,272.5,675,SBD,3
 M,Wraps,Pro Open,100,Julio Serrano,98.25,332.5,172.5,337.5,842.5,SBD,1
 M,Multi-ply,Pro Master 50-54,100,Rob Schmidt,98.79,285,192.5,255,732.5,SBD,1
-M,Raw,Amateur Open,110,Justin Haskins,107.95,,155,250,405,SBD,1
-M,Wraps,Pro Teen 18-19,110,Grant Brubaker,109.68,,132.5,225,357.5,SBD,1
-M,Wraps,Pro Open,110,Ryan Kennedy,106.05,,145,222.5,367.5,SBD,2
-M,Wraps,Amateur Open,110,Sam Tefft,106.96,,187.5,245,432.5,SBD,1
-M,Wraps,Pro Open,110,Anthony Diaz,108.32,,167.5,297.5,465,SBD,1
-M,Wraps,Pro Open,125,Ryan Conley,114.31,,197.5,287.5,485,SBD,1
-M,Raw,Pro Open,125,Andy Polk,117.93,,160,307.5,467.5,SBD,1
-M,Wraps,Amateur Open,140,Lucas Vogel,129.18,,165,250,415,SBD,1
-M,Wraps,Pro Open,140+,Andrew Olaya,149.69,,175,287.5,462.5,SBD,1
+M,Raw,Amateur Open,110,Justin Haskins,107.95,,155,250,405,BD,1
+M,Wraps,Pro Teen 18-19,110,Grant Brubaker,109.68,,132.5,225,357.5,BD,1
+M,Wraps,Pro Open,110,Ryan Kennedy,106.05,,145,222.5,367.5,BD,2
+M,Wraps,Amateur Open,110,Sam Tefft,106.96,,187.5,245,432.5,BD,1
+M,Wraps,Pro Open,110,Anthony Diaz,108.32,,167.5,297.5,465,BD,1
+M,Wraps,Pro Open,125,Ryan Conley,114.31,,197.5,287.5,485,BD,1
+M,Raw,Pro Open,125,Andy Polk,117.93,,160,307.5,467.5,BD,1
+M,Wraps,Amateur Open,140,Lucas Vogel,129.18,,165,250,415,BD,1
+M,Wraps,Pro Open,140+,Andrew Olaya,149.69,,175,287.5,462.5,BD,1
 F,Raw,Amateur Master 70-74,60,Judith Reed,59.87,,57.5,92.5,150,BD,1
 F,Raw,Pro Master 40-44,56,Miriam Rojas,55.34,,47.5,100,147.5,BD,1
 M,Raw,Pro Teen 18-19,82.5,Kasey Kaufmann,75.84,,112.5,185,297.5,BD,1

--- a/meet-data/rps/1733/lifters.csv
+++ b/meet-data/rps/1733/lifters.csv
@@ -42,14 +42,14 @@ M,Wraps,Pro Open,100,Andrew O'Dell,97.98,235,167.5,272.5,675,SBD,3
 M,Wraps,Pro Open,100,Julio Serrano,98.25,332.5,172.5,337.5,842.5,SBD,1
 M,Multi-ply,Pro Master 50-54,100,Rob Schmidt,98.79,285,192.5,255,732.5,SBD,1
 M,Raw,Amateur Open,110,Justin Haskins,107.95,,155,250,405,BD,1
-M,Wraps,Pro Teen 18-19,110,Grant Brubaker,109.68,,132.5,225,357.5,BD,1
-M,Wraps,Pro Open,110,Ryan Kennedy,106.05,,145,222.5,367.5,BD,2
-M,Wraps,Amateur Open,110,Sam Tefft,106.96,,187.5,245,432.5,BD,1
-M,Wraps,Pro Open,110,Anthony Diaz,108.32,,167.5,297.5,465,BD,1
-M,Wraps,Pro Open,125,Ryan Conley,114.31,,197.5,287.5,485,BD,1
+M,Raw,Pro Teen 18-19,110,Grant Brubaker,109.68,,132.5,225,357.5,BD,1
+M,Raw,Pro Open,110,Ryan Kennedy,106.05,,145,222.5,367.5,BD,2
+M,Raw,Amateur Open,110,Sam Tefft,106.96,,187.5,245,432.5,BD,1
+M,Raw,Pro Open,110,Anthony Diaz,108.32,,167.5,297.5,465,BD,1
+M,Raw,Pro Open,125,Ryan Conley,114.31,,197.5,287.5,485,BD,1
 M,Raw,Pro Open,125,Andy Polk,117.93,,160,307.5,467.5,BD,1
-M,Wraps,Amateur Open,140,Lucas Vogel,129.18,,165,250,415,BD,1
-M,Wraps,Pro Open,140+,Andrew Olaya,149.69,,175,287.5,462.5,BD,1
+M,Raw,Amateur Open,140,Lucas Vogel,129.18,,165,250,415,BD,1
+M,Raw,Pro Open,140+,Andrew Olaya,149.69,,175,287.5,462.5,BD,1
 F,Raw,Amateur Master 70-74,60,Judith Reed,59.87,,57.5,92.5,150,BD,1
 F,Raw,Pro Master 40-44,56,Miriam Rojas,55.34,,47.5,100,147.5,BD,1
 M,Raw,Pro Teen 18-19,82.5,Kasey Kaufmann,75.84,,112.5,185,297.5,BD,1


### PR DESCRIPTION
Ho boy, this one has problems.  From line 44-52 starting with Justin Haskins and ending with Andrew Olaya each lifter's bench result is the same as their deadlift result, this seems uncanny and impossible. All their squat results are much lower resembling bench numbers.  What I fear happened here is where they were inputting the data at the meet they accidentally copied the bench and deadlift data over one row and overwrote the squat and bench data for those 9 lifters.  I can fix it so that it shows the data correctly in the bench and deadlift columns but there is no way for me to know what those lifter's results in squat were.  Otherwise I guess we treat it as a push-pull?  What do you think the best course of action is here?