### PR TITLE
Update lifters.csv

### DIFF
--- a/meet-data/cpf/1604/lifters.csv
+++ b/meet-data/cpf/1604/lifters.csv
@@ -1,4 +1,4 @@
-Name,Age,Sex,Equipment,Division,BodyweightKg,WeightClassKg,Bench1Kg,Bench2Kg,Bench3Kg,BestBenchKg,TotalKg,Place,Event
+Name,Age,Sex,Equipment,Division,BodyweightKg,WeightClassKg,Bench1LBS,Bench2LBS,Bench3LBS,BestBenchLBS,TotalLBS,Place,Event
 Isabelle Lanteigne,14,F,Raw,F-T1R,73.2,75,95,-100,100,100,100,1,B
 Patti Sheeby,60,F,Raw,F-M5R,78.7,82.5,100,105,-110,105,105,1,B
 Birgit Elssner,40,F,Raw,F-M1R,152.3,90+,100,115,130,130,130,1,B


### PR DESCRIPTION
This one looks a lot like the other CPF meet from earlier with inordinately high numbers although as it is bench only it is possible that the lifts could all just be multi-ply rather than raw.  (otherwise there are a couple all time world records coming out of this small CPF meet...)