### PR TITLE
Update social-media.csv

### DIFF
--- a/lifter-data/social-media.csv
+++ b/lifter-data/social-media.csv
@@ -2,6 +2,7 @@ Name,Instagram
 Aaron Palko,oklap
 Abby Burg,anb614
 Abner Nazario,abner_n181
+Adam Leidigh,meathead_adam
 Adam Ramzy,arramzy
 Alan Thrall,untamedstrength
 Alastair MacNicol,amacnicol
@@ -31,6 +32,7 @@ Aria Attia,bigpoppachizl
 Arthur Lynch,arthurlynch
 Ashley Cooper,coop_strong
 Ashton Rouska,ashh117
+Austin Ayala,amichael165
 Austin Baraki,a.z.b
 Austin Skeens,powerskeeter
 Barbara Lee,msbarbellbarbie
@@ -78,6 +80,7 @@ Chris Duffin,mad_scientist_duffin
 Chris Dunn,m10ak3y
 Chris Janek,tankstrainingfacility
 Chris Karmin,cm_k40
+Chris Lentini,lentiniliftsheavy
 Chris Ramos,chrisramos007
 Christine Castro,sneakersoverstilettos
 Christophe Rebreyend,chreizr
@@ -139,6 +142,7 @@ Francesco Catalano,f_catalano
 Gabriel Velasco,gabrielvelascocscs
 Garrett Bailey,bottesy
 Garrett Blevins,garrettblessings
+Gary Hunter,ghunter_champ
 Gawain Johnstone,85gunit
 Gerald Dionio,tiny_n_tuff
 Gina Aversa,ginahalfwolf
@@ -199,6 +203,7 @@ Joe Seiden,trashcan_joe
 Joe Sullivan,joesullivanpowerlifter
 Joey Ma,flatbenchjoe
 Joey Tango,pootietango
+John Fayer,fayerjw
 John Haack,bilbo_swaggins181
 John Halloran,skiing.highlander
 John Kirby,kingkirby84
@@ -208,12 +213,14 @@ Jonathan Akagha,jayyyy99
 Jonathan Cayco,league_of_lifting
 Jonnie Candito,canditotraininghq
 Jordan Feigenbaum,jordan_barbellmedicine
+Jordan Jarrell,dadbod220
 Jordan Lawler,chromedome106
 Jordan Shallow,the_muscle_doc
 Jordan Wong,wongstwong
 Joseph Adamo,joseph_adamo1
 Joseph Park,dialect1luv
 Joseph Peña,_hollapena
+Josh Ellis,bearjewjosh
 Josh Lentz,jlentz220
 Josh Morris,joshmmorris24
 Josue Garzoria,garzoria98
@@ -273,6 +280,7 @@ Linda Chan,musclemaus
 Lizette Salgado,lizardd05
 LS McClain,lsm97m
 Lu Shalili,lu.zilla
+Luke Dreier,ldreier_bigiron
 Luke Richardson,lukeerichardson
 Maaike De Vries,maaike_de_vries
 Maliek Derstine,maliekderstine
@@ -347,6 +355,7 @@ Rachael Lynn,rachael.lynn.fit
 Rachel Anyi,rvchelvnyi
 Rachel Younker,rachelyounker
 Rainer Altmäe,rainer198
+Rait Sagor,rocla_900
 Ray Jimenez,powerweightray
 Ray Williams,optimusprime_334
 Rebecca Holcomb,prettystrongbec
@@ -387,6 +396,7 @@ Scott Cartwright,bighosscartwright
 Sean Culnan,sculnan
 Sean Noriega,kissmyarch
 Sergey Fedosienko,sergey_fedosienko
+Seth Bowles,140horse
 Shana Miller,__shana_miller__
 Shane Hammock,rshammock55
 Shanna McKenzie,shanna.mckenzie


### PR DESCRIPTION
Added the following lifters in alphabetical order,

Jordan Jarrell
Austin Ayala
Adam Leidigh
Gary Hunter
Yianni Manousaridis
Josh Ellis
Rait Sagor
Chris Lentini
Seth Bowles
Gary Hunter
John Fayer
Luke Dreier