### PR TITLE
Update social-media.csv

### DIFF
--- a/lifter-data/social-media.csv
+++ b/lifter-data/social-media.csv
@@ -2,10 +2,12 @@ Name,Instagram
 Aaron Palko,oklap
 Abby Burg,anb614
 Abner Nazario,abner_n181
+Adam Ferchen,aferchen
 Adam Leidigh,meathead_adam
 Adam Ramzy,arramzy
 Alan Thrall,untamedstrength
 Alastair MacNicol,amacnicol
+Alex Ghossein,alex_the_sicko
 Alex Viada,alex.viada
 Alexey Sivokon,sivokon
 Ali Squiller,squillerz
@@ -41,10 +43,12 @@ Barry Pigott,barryp91
 Ben Gianacakos,bengianacakos
 Ben O'Brien,b3nobrien8
 Ben Pollack,phdeadlift
+Ben Puccio,benpuccio
 Ben Rice,ben.rice.10
 Bill Newman,isaku900
 Bill Tenerelli,billbro_liftins
 Billy Mimnaugh,bmimnaugh
+BJ Whitehead,bjwhitehead275
 Blaine Sumner,thevanillagorilla92
 Bobby Vongphachanh,bigbootyboobybruh
 Bonica Lough,bubblypowerlifter
@@ -54,6 +58,7 @@ Brandon Franklin,frankdaddy27
 Brandon Lilly,brandonlilly3
 Brandon Perdue,perdueb84
 Brantley Thornton,brantleythornton
+Brett Chrisman,brettchrisman
 Brett Gibbs,bg_waiweight
 Brian Carroll,briancarroll81
 Brittany Pryor,jadessence
@@ -106,6 +111,7 @@ Danielle Couture,dee.couture
 Danielle Overcash,danicashdpt
 Daphne Zhang,daphne_wants_a_6pack
 Dave Hoff,mr.3k5
+David Lomeli,lomeli198
 David Opare-Addo,hulkstrong6
 David Osborn,daveatops
 David Troutt,dtrouttpowerlifter
@@ -181,6 +187,7 @@ Jeanine Whittaker,jwhitt206
 Jeff Cotter,senorcotter
 Jeff Justo,friffstar
 Jeff Younker,babyhuey2k
+Jen Smith,powerliftersdiary
 Jenn Rotsinger,jrotsinger
 Jennifer Millican,jenmillican
 Jennifer Thompson,jenthompson132
@@ -203,6 +210,7 @@ Jimmy Paquet,jimpaquet
 Joanna Rieber,littlejo.r
 Joe Seiden,trashcan_joe
 Joe Sullivan,joesullivanpowerlifter
+Joell Shell,floatlikerock
 Joey Ma,flatbenchjoe
 Joey Tango,pootietango
 John Fayer,fayerjw
@@ -213,6 +221,7 @@ John Paul Cauchi,5trong
 John Rivas,johnrivas110
 Jonathan Akagha,jayyyy99
 Jonathan Cayco,league_of_lifting
+Jonathan Harder,become_a_beast_181_2k
 Jonnie Candito,canditotraininghq
 Jordan Feigenbaum,jordan_barbellmedicine
 Jordan Jarrell,dadbod220
@@ -316,6 +325,7 @@ Michael Wong,magicmike5580
 Michael Zundelevich,mzundy81
 Mike James,mike.kimchi
 Mike Lackey,mlack15
+Mike McGivern,mikemcgivern
 Mike Rubinetti,ironmikerubes
 Mikhail Koklyaev,koklyaev_mikhail
 Mindy Chen,baconandbiceps
@@ -343,6 +353,7 @@ Noel Gragasin,noel.gragasin
 Noelia Corona-Terry,ncoronaterry18
 Oakley Walraven,ironangler
 Odell Manuel,odellmanuelelitepowerlifter
+Oleksii Melnyk,melnyk_olexii
 Oran Smith,oranksmith
 Owen Hubbard,ohubb
 Pamela Anderson,pamv_anderson
@@ -383,6 +394,7 @@ Rostislav Petkov,ross_petkov
 Russell Hutchins,russ_hutchins
 Ruthie Luna,r.lunaaa
 Ruud Kassing,kassingcouch
+Ryan Celli,ryancelli
 Ryan King,ryandking
 Ryan Spencer,politicalmuscle
 Sam Bernstein,samuellbernstein
@@ -440,6 +452,7 @@ Tee Cummins,tee_cummins
 Tee Popoola,teepopoola
 Teresa Parsons,teresaparsons
 Tess Heaslip,tessredsky
+Thomas Blackwell,bigtommyblack
 Tiffany Leung,tinytiff97
 Tina Daneshmand,tina_tornado
 Tiny Meeker,tinymeeker


### PR DESCRIPTION
Added the following lifters in alphabetical order

Jen Smith
Jonathan Harder
Mike McGivern
Oleksii Melnyk
Joel Shell
Brett Chrisman
Adam Ferchen
David Lomeli
Ryan Celli
Ben Puccio
Alex Ghossein
Thomas Blackwell
BJ Whitehead