### PR TITLE
Update social-media.csv

### DIFF
--- a/lifter-data/social-media.csv
+++ b/lifter-data/social-media.csv
@@ -12,6 +12,7 @@ Alex Viada,alex.viada
 Alexey Sivokon,sivokon
 Ali Squiller,squillerz
 Alison Crowdus,powerpack_ali
+Allen Baria,allen.baria.ab
 Alora Griffiths,aloragriffiths
 Amber Abweh,swoleesi
 Amenah Razeghi,onestrongnurse
@@ -34,6 +35,7 @@ Anthony Sberna,sbernaslam
 Antti Savolainen,a_savolainen
 April Shumaker,aprilshumaker
 Aria Attia,bigpoppachizl
+Arkadiy Shalokha,shalokha1983
 Arthur Lynch,arthurlynch
 Ashley Cooper,coop_strong
 Ashton Rouska,ashh117
@@ -53,6 +55,7 @@ Bill Tenerelli,billbro_liftins
 Billy Mimnaugh,bmimnaugh
 BJ Whitehead,bjwhitehead275
 Blaine Sumner,thevanillagorilla92
+Blake Horton,blakehorton23
 Bobby Vongphachanh,bigbootyboobybruh
 Bonica Lough,bubblypowerlifter
 Brad Arbic,brad_arbic
@@ -65,6 +68,7 @@ Brett Chrisman,brettchrisman
 Brett Gibbs,bg_waiweight
 Brian Carroll,briancarroll81
 Brittany Pryor,jadessence
+Brittany Shackelford,brittany_shack
 Bryce Krawczyk,calgarybarbell
 Bryce Lewis,bryce_tsa
 Cailer Woolam,doctor.deadlift
@@ -108,6 +112,7 @@ Dalton Cissell,dcissell5
 Dalton LaCoe,53kglifter
 Damien Pezzuti,damienpezzuti
 Dan Green,dangreenpowerlifter
+Dan Kovacs,dankovacs2500
 Dane Dillon,danejdillon
 Daniel Bell,dbell_74
 Daniel Casson,static_athlete2200
@@ -117,6 +122,7 @@ Danielle Couture,dee.couture
 Danielle Overcash,danicashdpt
 Daphne Zhang,daphne_wants_a_6pack
 Dave Hoff,mr.3k5
+David Douglas,davidthebeastdouglas
 David Lomeli,lomeli198
 David Opare-Addo,hulkstrong6
 David Osborn,daveatops
@@ -177,6 +183,7 @@ Ian Bell,iandeadlifts
 Inna Filimonova,filimonovainna555
 Irina Vitman,poison_ivee93
 Isabella von Weissenberg,ivweissenberg
+Jabez Burford,jabez_burford
 Jaclyn Do,jaclyndo
 Jacob Kurant,jacobkurant
 Jacob Welch,jacobwelch08
@@ -216,10 +223,12 @@ Jessica Brown,tucpowerlifting
 Jessica Giannina,jlgiannina
 Jessika Byrd,lookitsabyrd
 Jezza Uepa,jezzauepa
+Jill Mills,1jill_mills
 Jillian Lew,jillian_lew
 Jimmie Pacifico,pacifico_power1
 Jimmy Paquet,jimpaquet
 Joanna Rieber,littlejo.r
+Jodie Burford,jodie_lanae
 Joe Seiden,trashcan_joe
 Joe Sullivan,joesullivanpowerlifter
 Joel Shell,floatlikerock
@@ -271,6 +280,7 @@ Kelly Branton,great_white_north_juggernaut
 Kelsey Horton,kelseyhorton1989
 Kenneth Coleman,kennethcoleman6268
 Kevin Oak,oakstrong
+Kevin Torres,pitbull_torres
 Kim Gustafsson,kim_lsk
 Kim Tran,agentvalentine
 Kimberly Walford,trackfu
@@ -327,6 +337,7 @@ Matt Disbrow,mdisbrow
 Matt Fryfogle,bigmattfryfogle
 Matt Mitchell,matt_bulldog_mitchell
 Matt Wenning,realmattwenning
+Mauro Spinardi,maurospinardicoach
 Meana Franco,meanafranco
 Megan Kitagawa,kittygawah
 Meicha Hardeman,yahwehsgeneral
@@ -360,6 +371,7 @@ Nathalie Moen Balhald,nathmoen
 Nathan Tanis,nathan_tanis
 Nicholas Brooks,nicholasbrooks25
 Nick Best,nickbeststrongman
+Nick Cook,cookiemonsta08
 Nick Kiger,kigerstrength
 Nick Ramey,nick_ramey
 Nicole Balkau,nikki_b11
@@ -418,6 +430,7 @@ Ruud Kassing,kassingcouch
 Ryan Celli,ryancelli
 Ryan King,ryandking
 Ryan Spencer,politicalmuscle
+Ryan Williams,ryan_williams77
 Sam Bernstein,samuellbernstein
 Sam Byrd,sambyrd1
 Samantha Bechard,sam.bechard
@@ -490,12 +503,14 @@ Trace Stewart,tjswole
 Trenton Wade,trewade198
 Trystan Oakley,oakleypowerlifting
 Tyler Fisher,tyler_tfstrength
+Tyler Obringer,tylerobringer
 Tyler Ward,wyler_tard88
 Vadym Dovhanyuk,vadymdovhanyuk
 Valerie King,valrking
 Victor Biryukov,v.biryukov_russianboss
 Victoria Lodise,victorialodise
 Vladislav Alhazov,vado.a
+Wayne Howlett,waynehowlettpl
 Will Crozier,wcroz
 Will Hunt,wj_hunt
 Yakov Ionin,yakovionin
@@ -504,5 +519,6 @@ Yianni Manousaridis,yianni50
 Yulia Shenkarenko,yulia_shenkarenko
 Yury Belkin,belkin_one_power
 Zac Meyers,thehulkmeyers
+Zach Homol,zachhomolpower
 Zachary Yamamoto,zmoto_
 Zahir Khudayarov,zahirkhudayarov


### PR DESCRIPTION
Added the following lifters in alphabetical order:

Alexis Eliopoulos
Jason Legrand
Ranson Lee
Ryan Williams
Allen Baria
Dan Kovacs
Jill Mills
David Douglas
Jodie Burford
Brittany Shackelford
Jabez Burford
Nick Cook
Tyler Obringer
Arkadiy Shalokha
Wayne Howlett
Zach Homol
Mauro Spinardi
Kevin Torres
Blake Horton