### PR TITLE
Update social-media.csv

### DIFF
--- a/lifter-data/social-media.csv
+++ b/lifter-data/social-media.csv
@@ -6,6 +6,7 @@ Abner Nazario,abner_n181
 Adam Ferchen,aferchen
 Adam Leidigh,meathead_adam
 Adam Ramzy,arramzy
+Adam Werner,big_wern
 Alan Thrall,untamedstrength
 Alastair MacNicol,amacnicol
 Alex Ghossein,alex_the_sicko


### PR DESCRIPTION
Added the only missing instagram for the invitational BOB4 lifters I could find, Adam Werner @sstangl 