### PR TITLE
Update lifters.csv

### DIFF
--- a/meet-data/spf-archive/0397/lifters.csv
+++ b/meet-data/spf-archive/0397/lifters.csv
@@ -50,5 +50,5 @@ WeightClassKg,Division,Name,Age,BodyweightKg,State,BestSquatKg,BestBenchKg,BestD
 110,Open,K.C. Burrows,27,109.23,OH,154.22,124.74,226.8,505.76,M,SBD,Wraps,2
 75,Junior,Brandon Bergen,23,71.21,OH,183.7,122.47,217.72,523.9,M,SBD,Wraps,2
 90,Junior,Joshua Selridge,21,89.45,OH,174.63,151.95,219.99,546.58,M,SBD,Wraps,1
-90,Teenage (18-19),Ryan Romey,,40.78,KY,,,272.16,272.16,M,D,Raw,1
+90,Teenage (18-19),Ryan Romey,,86.14,KY,,,272.16,272.16,M,D,Raw,1
 52,Master (55-59),Cathy Eaton,59,50.26,OH,,,81.65,81.65,F,D,Raw,1


### PR DESCRIPTION
Seems like a pretty simple mistake, says he's in the -198 class but them lists his weight as 89.9, was probably supposed to be 189.9 and the 1 was misplaced.  
189.9/2.2046 = about 86.14, that said it is also possible that 89.9 was his metric weight, as it is just under 90kg (198lb) It would be strange if they notated it that way as the rest of the results have the bodyweights in pounds...