### PR TITLE
Update lifters.csv

### DIFF
--- a/meet-data/spf/1750/lifters.csv
+++ b/meet-data/spf/1750/lifters.csv
@@ -34,7 +34,7 @@ SBD,Open,Wraps,Lexington Long,M,AR,29,90,83.01,212.5,150,220,582.5,1
 SBD,Master (50-54),Wraps,Loria Fry,F,AR,53,75,73.03,147.5,107.5,167.5,422.5,1
 SBD,Open,Wraps,Lucas Graham,M,AR,27,100,99.43,192.5,140,237.5,570,3
 SBD,Open,Wraps,Matt Fryfogle,M,MS,34,140,136.08,425,250,350,1025,1
-SBD,Sub-master,Wraps,Mike Saravane,M,AR,33,140+,157.49,287.5,200,272.5,745,1
+SBD,Sub-master,Wraps,Mike Saravane,M,AR,33,140+,157.49,287.5,200,272.5,760,1
 SBD,Open,Wraps,Miles Bailey,M,AR,32,82.5,80.06,215,147.5,272.5,635,1
 SBD,Sub-master,Wraps,Melton Menjivar,M,AR,35,110,107.95,295,200,295,790,1
 SBD,Open,Wraps,Nathan Burford,M,AR,29,100,99.79,285,190,275,750,1

--- a/meet-data/spf/1750/lifters.csv
+++ b/meet-data/spf/1750/lifters.csv
@@ -27,14 +27,14 @@ SBD,Junior,Raw,John Wilson Tharp,M,AR,22,82.5,81.1,192.5,135,220,547.5,1
 SBD,Open,Raw,Josue Rodriguez,M,AR,24,82.5,80.29,142.5,105,165,412.5,2
 SBD,Junior,Wraps,Kellin Lee,M,AR,23,110,106.37,252.5,137.5,240,630,1
 BD,Master (50-54),Raw,Kent Fry,M,AR,54,110,105.23,,157.5,232.5,390,1
-SBD,Open,Wraps,Kevin Tolly,M,AR,28,140,153.77,252.5,157.5,250,660,3
-SBD,Sub-master,Raw,LaRodrick Duncan,M,AR,34,140,151.27,365,220,307.5,892.5,1
+SBD,Open,Wraps,Kevin Tolly,M,AR,28,140+,153.77,252.5,157.5,250,660,3
+SBD,Sub-master,Raw,LaRodrick Duncan,M,AR,34,140+,151.27,365,220,307.5,892.5,1
 SBD,Open,Wraps,Laura Hartley,F,AR,31,56,53.75,102.5,65,137.5,305,1
 SBD,Open,Wraps,Lexington Long,M,AR,29,90,83.01,212.5,150,220,582.5,1
 SBD,Master (50-54),Wraps,Loria Fry,F,AR,53,75,73.03,147.5,107.5,167.5,422.5,1
 SBD,Open,Wraps,Lucas Graham,M,AR,27,100,99.43,192.5,140,237.5,570,3
 SBD,Open,Wraps,Matt Fryfogle,M,MS,34,140,136.08,425,250,350,1025,1
-SBD,Sub-master,Wraps,Mike Saravane,M,AR,33,140,157.49,272.5,200,272.5,745,1
+SBD,Sub-master,Wraps,Mike Saravane,M,AR,33,140+,157.49,287.5,200,272.5,745,1
 SBD,Open,Wraps,Miles Bailey,M,AR,32,82.5,80.06,215,147.5,272.5,635,1
 SBD,Sub-master,Wraps,Melton Menjivar,M,AR,35,110,107.95,295,200,295,790,1
 SBD,Open,Wraps,Nathan Burford,M,AR,29,100,99.79,285,190,275,750,1


### PR DESCRIPTION
Fixed Kevin Tolley, Mike Saravane, and LaRodrick to 140+ instead of 140 and corrected a mistake on Mike's best squat verified by Jesse Rodgers. @sstangl 