### PR TITLE
Update social-media.csv

### DIFF
--- a/lifter-data/social-media.csv
+++ b/lifter-data/social-media.csv
@@ -46,6 +46,7 @@ Andre' Easter II,easterstrong
 Andrea White,supazanii
 Andres Ramos,andres59kg_
 Andrew Desesa,deflex_daddy_sir
+Andrew Hause,andrewhause
 Andrew Herbert,herbietheluvbug
 Andrew King,bigfatfuk
 Andrew Le,megamang74
@@ -179,6 +180,7 @@ Christine Beauchamp,omnomnomnomcookies
 Christine Castro,sneakersoverstilettos
 Christophe Rebreyend,chreizr
 Christopher Aydin,aydin_tsa
+Christopher Blanquera,chrisblanquera
 Christopher Cianci,shanky041809
 Christopher Karmin,cm_k40
 Christopher Vann,vann_man
@@ -205,6 +207,7 @@ Cryssa Dragon,cryssaboo
 Crystal Tate,ctate87
 Cynthia Leu,cynthialeu
 Cyprian Thompson Jr,bobby.booshay
+Dakoda Gayne,keg_with_abs
 Dakoda Plumridge,dakoda_fanning
 Dallas Bey,dallasbey
 Dallas Norris,norrisstrong
@@ -264,11 +267,13 @@ Dylan Mayer,dylliemays
 Dylan McKinney,_dylan.m_
 Dylan Polo,dylanpolo__
 Ed Coan,eddycoan
+Ed Knoblock,ed.k52
 Edan Davey,edandavey
 Eddie Berglund,strongeddie
 Eduard Khanjyan,eduardkhanjyan
 Edward Alicdan Jr,jralicdan
 Edwin Nash,edwin_nash92
+Eli Burks,eliburks3
 Elizabeth Craven,lizpowerlifts
 Ellen Seidel,ellen.seidel
 Elliott Shults,stronghouse_elliottshults
@@ -416,6 +421,7 @@ Jessika Byrd,lookitsabyrd
 Jezza Uepa,jezzauepa
 Jill Mills,1jill_mills
 Jillian Lew,jillian_lew
+Jim Benson,warriorelite49
 Jim Corvin,utkaveman
 Jimmie Pacifico,pacifico_power1
 Jimmy Paquet,jimpaquet
@@ -532,6 +538,7 @@ Kyle Hendricks,khendrickspower
 Kyle Hunt,huntfitness
 Kyle Keough,kylekeough165
 Kyle Milnes,kjmilnes_astc
+Kyle Sheridan,sheridanstrong
 Kyle Stewart,kylebenches
 Lacey Massari,littlelaceylulu
 Lacey Mesley,_the_lace_
@@ -569,6 +576,7 @@ Lu Shalili,lu.zilla
 Lucas Graham,elzie870
 Lucas Martin,lucasmartinfit
 Lucian York,toobigformyshirt
+Luigi Fagiani,luigifagiani
 Luke Dreier,ldreier_bigiron
 Luke Poli,lukepoli
 Luke Richardson,lukeerichardson
@@ -732,6 +740,7 @@ Rodrigo Manzo,rodrigo.manzo
 Roman Eremashvili,eremashvili.roma
 Ronald Tarvin,sir_gymratfitness
 Ronald Tolie,see_ron_squat_and_stuff
+Rondel Hunte,deadlift_lord868
 Rory Girvan,rory__girvan
 Ross Leppala,ross_rts
 Rostislav Petkov,ross_petkov


### PR DESCRIPTION
Added Christopher Blanquera, Luigi Fagiani, Rondel Hunte, Eli Burks, Andrew Hause, Kyle Sheridan, Jim Benson, Ed Knoblock, and Dakoda Gayne in alphabetical order @sstangl 