### PR TITLE
Update social-media.csv

### DIFF
--- a/lifter-data/social-media.csv
+++ b/lifter-data/social-media.csv
@@ -54,7 +54,7 @@ Andrew Desesa,deflex_daddy_sir
 Andrew Hause,andrewhause
 Andrew Herbert,herbietheluvbug
 Andrew King,bigfatfuk
-Andrew Le,megamang74
+Andrew Le,vietiron
 Andrew Ottaway,weak_lil_guy
 Andrew Sandoval,drewbsh56
 Andrew Shahbazian,therealshahbazian
@@ -181,7 +181,6 @@ Chris Lentini,lentiniliftsheavy
 Chris Ramos,chrisramos007
 Chris Stamatiou,critta_
 Chris Tyrrell,christopher_tyrrell
-Chris Welty,chris_w.lbc.75kg
 Christian Anto,ant_toe
 Christian Habihirwe,chestnificent
 Christian Kearney,ya_im_dat_dude
@@ -267,7 +266,7 @@ Dennis Bitetti,dennisbitetti
 Dennis Cornelius,denniscornelius500
 Derek Dickinson,dderelick
 Derek Viet,derekdtrain
-Derrington Wright,godgivenstrength
+Derrington Wright,the_pineapple_king_
 Didzis Zarins,zarinsdidzis
 Dima Rumanov,dimarumanov
 Dmitry Nasonov,_nasonov_d
@@ -341,7 +340,6 @@ Gary Hunter,ghunter_champ
 Gavin Havard,gavinhavard
 Gawain Johnstone,85gunit
 Gehad Quraan,geethept
-George Nelson,george_swooney
 Gerald Dionio,tiny_n_tuff
 Geramy Alexander,g.a.powerlifting.181
 Gerard Frederic-Lama,gerard_lama
@@ -389,7 +387,7 @@ Jacqueline Wickens,jwicky9
 Jaeger Low,jaegernawt
 Jaisyn Mike,mr.athletic_over_everything
 Jake Frazier,jakefrazierpowerlifting
-Jake Hartman,jakexhartman
+Jake Hartman,hartmanstrength
 Jake Johns,bigscboy
 Jake Thiele,jakeisalwaysright
 James Fowler,gainz4dayz_
@@ -481,7 +479,7 @@ Jon Wawro,wonjawro
 Jonathan Akagha,jayyyy99
 Jonathan Cayco,league_of_lifting
 Jonathan Cotton,cottonsense
-Jonathan Harder,come_october
+Jonathan Harder,gone2cold
 Jonathan Rodgers #1,jonisradical
 Jonnie Candito,canditotraininghq
 Jonny Gardner,jonnyg_1980
@@ -525,7 +523,7 @@ Justin Wilson,jwils_mtnbkr_pwrlftr
 Kade Weber,kadeweber2150
 Kaine Boudreau,kaineboudreau
 Kaitlin McCanless,kaitlintattoos
-Karl Hjelholt,khjelholt7
+Karl Hjelholt,thegreatwhiteorc
 Karrie Macknair,k__mack
 Kate Hart,bratsy_cline
 Katelyn O'Donnell,k_odon
@@ -628,7 +626,7 @@ Marco Galindo,marcogalindojr
 Marcos Rivera,marco.rivera14
 Marcus Morris,marcusmorris15
 Maria Htee,maria_htee
-Maria Ramos,mariaramos4803
+Maria Ramos,maria_ramos_powerlifting
 Mariah Corke,mariahcat
 Marianna Gasparyan,power_mayan
 Mariella Fisher,mari3lla_pl
@@ -651,7 +649,7 @@ Matt Fryfogle,bigmattfryfogle
 Matt Mitchell,matt_bulldog_mitchell
 Matt Piscitelli,mattpisc
 Matt Wenning,realmattwenning
-Matthew Arremony,lil_screamer_snurr
+Matthew Arremony,lil_tortoise_snurr
 Matthew Jones,yaboimattjones
 Matthew Sollay,matthew_sollay
 Mauro Spinardi,maurospinardicoach
@@ -686,7 +684,7 @@ Mike Lackey,mlack15
 Mike McGivern,mikemcgivern
 Mike Rubinetti,ironmikerubes
 Mike Saravane,mikemoose83
-Mike Scherer,sgtosirispowerlifting
+Mike Scherer,scheeerpower
 Mikhail Koklyaev,koklyaev_mikhail
 Mindy Chen,baconandbiceps
 Miranda Chisom,mirandybrook
@@ -728,9 +726,7 @@ Niki Sims,vera_nahce
 Noah Brooks,noahtbrooks
 Noel Gragasin,noel.gragasin
 Noelia Corona-Terry,ncoronaterry18
-Oakley Walraven,ironangler
 Odell Manuel,odellmanuelpowerlifter
-Ogden J Myklebust III,og_triple_0g
 Oleksii Melnyk,melnyk_olexii
 Oran Smith,oranksmith
 Owen Hubbard,ohubb
@@ -752,11 +748,11 @@ Petr Petráš,petras.petr
 Phillip Brown,flipdbrown
 Pip Brown,pip__brown
 Priscilla Ribic,priscillaribic
-Quessandra Catlett,quessandra
+Quessandra Catlett,squatruhh
 Quinn Clarke,papagrizzles
 Rachael Johnson,bulkingk9
 Rachel Anyi,rvchelvnyi
-Rachel Kiefer,rkplifts
+Rachel Kiefer,braids_and_barbells
 Rachel Orbach,raychrrles
 Rachel Younker,rachelyounker
 Rainer Altmäe,rainer198
@@ -933,7 +929,6 @@ Trevor Myhre,the_liftertarian
 Troy Mulkey,trobertsonm
 Trystan Oakley,oakleypowerlifting
 Tyler Cummings,tcum_48pl
-Tyler Fisher,tyler_tfstrength
 Tyler Mingus,tylershmingus
 Tyler Obringer,tylerobringer
 Tyler Ward,wyler_tard88


### PR DESCRIPTION
Corrected instagrams for Andrew Le, Derrington Wright, Jake Hartman, Jonathan Harder, Karl Hjelholt, Maria Ramos, Matthew Arremony, Mike Scherer, Quessandra Catlett, and Rachel Kiefer. Deleted instagrams for Chris Welty, George Nelson, Oakley Walraven, Ogden J Myklebust III, and Tyler Fisher. @sstangl 