### PR TITLE
Update entries.csv

### DIFF
--- a/meet-data/xpc/2012-intl-open/entries.csv
+++ b/meet-data/xpc/2012-intl-open/entries.csv
@@ -6,7 +6,7 @@ WeightClassKg,Division,Name,Equipment,BodyweightKg,BestSquatKg,BestBenchKg,BestD
 82.5,Amateur Teen 18,Marc Anthony Vandermolen,Multi-ply,77.11,229.06,104.33,226.8,560.19,1,M,SBD,,,
 82.5,Amateur Teen 19,Jimmy Olivieri,Multi-ply,81.65,263.08,,,,DQ,M,SBD,,,
 90,Amateur Teen 16,Griffen Yeager,Raw,88,201.85,127.01,229.06,557.92,1,M,SBD,,,
-90,Amateur Teen 17,Dustin Pfeiffer,Multi-ply,89.58,181.44,133.81,179.17,494.42,1,M,SBD,142.88,188.24,512.56
+90,Amateur Teen 17,Dustin Pfeiffer,Multi-ply,89.58,181.44,133.81,179.17,494.42,1,M,SBD,,142.88,188.24
 90,Amateur Teen 18-19,Brandon Tunquist,Raw,87.54,229.06,142.88,292.57,664.51,1,M,SBD,,,
 140+,Amateur Teen 19,Joey Rogers,Multi-ply,142.43,362.87,281.23,242.67,886.77,1,M,SBD,,,
 75,Pro Open,Reggie Dukes,Wraps,74.62,226.8,172.37,258.55,657.71,1,M,SBD,,,


### PR DESCRIPTION
Clearly this -198 lifter did not deadlift 1130lbs
This was the code in the results file:
<td>198</td>

    <td>AM</td>

    <td>Teen 17</td>

    <td>Dustin Pfeiffer</td>

    <td align="right">197.5</td>

    <td align="right">400</td>

    <td align="right">295</td>

    <td align="right">395</td>

    <td>1090</td>

  </tr>

  <tr>

    <td>&nbsp;</td>

    <td>&nbsp;</td>

    <td>&nbsp;</td>

    <td>&nbsp;</td>

    <td align="right">&nbsp;</td>

    <td align="right">4th</td>

    <td align="right">315</td>

    <td align="right">415</td>

    <td>1130</td>
From this I gleaned that the best attempts in 3 lifts were 400/295/395 for a total of 1090, the 4th lifts for bench and dead were 315/415.  They list a "4 lifts total" of 1130 but this is moot to us as we only recognize totals from 3 attempts.