### PR TITLE
Update entries.csv

### DIFF
--- a/meet-data/rps/1779/entries.csv
+++ b/meet-data/rps/1779/entries.csv
@@ -43,7 +43,7 @@ M,Wraps,Pro Master 45-49,140+,Dale Ortiz,149.1,282.5,192.5,282.5,757.49,SBD,1
 M,Wraps,Amateur Master 50-54,82.5,Richie Frank,80.85,122.5,92.5,182.5,397.5,SBD,1
 M,Wraps,Amateur Master 50-54,90,Leon Tamayo,89.95,217.5,147.5,235,599.99,SBD,1
 M,Wraps,Amateur Open,75,Nicholas Brooks,75,250,145,237.5,632.49,SBD,1
-M,Wraps,Amateur Open,75,AJ Foxx,74.75,207.5,120,210,537.49,SBD,1
+M,Wraps,Amateur Open,75,AJ Foxx,74.75,207.5,120,210,537.49,SBD,2
 M,Wraps,Amateur Open,82.5,Lars Allison,82.35,192.5,122.5,272.5,587.49,SBD,2
 M,Wraps,Amateur Open,82.5,Chance Ray,81.15,190,132.5,242.5,564.99,SBD,3
 M,Wraps,Amateur Open,82.5,Brandon George,81,162.5,110,175,447.5,SBD,4

--- a/meet-data/rps/1779/entries.csv
+++ b/meet-data/rps/1779/entries.csv
@@ -42,7 +42,7 @@ M,Wraps,Pro Master 40-44,125,Derek Jarman,116.25,307.49,215,300,822.49,SBD,1
 M,Wraps,Pro Master 45-49,140+,Dale Ortiz,149.1,282.5,192.5,282.5,757.49,SBD,1
 M,Wraps,Amateur Master 50-54,82.5,Richie Frank,80.85,122.5,92.5,182.5,397.5,SBD,1
 M,Wraps,Amateur Master 50-54,90,Leon Tamayo,89.95,217.5,147.5,235,599.99,SBD,1
-M,Wraps,Amateur Open,82.5,Nicholas Brooks,75,250,145,237.5,632.49,SBD,1
+M,Wraps,Amateur Open,75,Nicholas Brooks,75,250,145,237.5,632.49,SBD,1
 M,Wraps,Amateur Open,75,AJ Foxx,74.75,207.5,120,210,537.49,SBD,1
 M,Wraps,Amateur Open,82.5,Lars Allison,82.35,192.5,122.5,272.5,587.49,SBD,2
 M,Wraps,Amateur Open,82.5,Chance Ray,81.15,190,132.5,242.5,564.99,SBD,3


### PR DESCRIPTION
The RPS changed Nicholas Brooks weight to 75 kg. exactly because they reportedly "messed up". So I put him in the 75 kg weight class as they report. http://meets.revolutionpowerlifting.com/results/2017-meet-results/2017-rps-texas-merry-gainzmas/ @sstangl 