### PR TITLE
Update social-media.csv

### DIFF
--- a/lifter-data/social-media.csv
+++ b/lifter-data/social-media.csv
@@ -47,6 +47,7 @@ Allen Baria,allen.baria.ab
 Allie Feras,trainhardpizzaharder
 Alora Griffiths,aloragriffiths
 Amador Rios,the1armani
+Amanda Bucci,amandabucci
 Amanda Kate Parker,amandakate
 Amanda Kohatsu,haparican
 Amber Abweh,swoleesi
@@ -229,8 +230,10 @@ Chris Hut,heyimchrisnotdennis
 Chris Janek,tankstrainingfacility
 Chris Lentini,lentiniliftsheavy
 Chris Ramos,chrisramos007
+Chris Ruden,chrisruden
 Chris Stamatiou,critta_
 Chris Tyrrell,christopher_tyrrell
+Chris Williams,cdubpower
 Christian Anto,ant_toe
 Christian Habihirwe,chestnificent
 Christian Kearney,ya_im_dat_dude
@@ -262,6 +265,7 @@ Cody Ray,codywray9811
 Cody Robbins,newegro
 Cody Tormoehlen,codytormoehlen
 Cole Niblett,swolegiblett
+Collin Whitney,ct_whitney
 Colin Wright,colywright
 Colleen Fitzpatrick,colleendf
 Collin Curtiss,colesoswoll
@@ -315,6 +319,7 @@ David Gray,davidgrayakalionpaw
 David Herrera,davidherrera1119
 David Isenberg,mr.isenberg
 David Lomeli,lomeli198
+David Lotito,davelotito
 David Opare-Addo,hulkstrong6
 David Osborn,daveatops
 David Raymond,davethebarbarian16
@@ -325,6 +330,7 @@ David Woolson,davidwoolson
 David Zyski,dzyski1730
 Davy Capriles,davydoesntdocardio
 Dawn Bogart,dawnbogart
+Dawson Windham,dawsonwindham
 Dayna McNeal,versus_myself
 Dean Chung,deanrilla
 Dean Panopoulos,deannyweenie92
@@ -345,7 +351,7 @@ Dmitry Nasonov,_nasonov_d
 Domenick Minnici,dom_minnici_powerlifter
 Dominique Toney,toney_montana1
 Donnie Ross,rosco_p_swoletrain
-Donnie Thompson,thompsonfatpad
+Donnie Thompson,thompsonbowtie
 Donovin Reyes,thstrongest
 Drew Cheatham,zookeeper_d
 Dustin Reed,i.know.squat
@@ -355,12 +361,14 @@ Dylan Mayer,dylliemays
 Dylan McKinney,_dylan.m_
 Dylan Polo,dylanpolo__
 Ed Coan,eddycoan
+Ed Koo,ed_koo
 Ed Knoblock,ed.k52
 Edan Davey,edandavey
 Eddie Berglund,strongeddie
 Eduard Khanjyan,eduardkhanjyan
 Eduardo Garcia,kimbo_halfslice_
 Edward Alicdan Jr,jralicdan
+Edward Koo,ed_koo
 Edward Ryckman,fast.eddie_181
 Edwin Nash,edwin_nash92
 Eli Burks,eliburks3
@@ -532,6 +540,7 @@ Jeff Barnes,bigbarndoor
 Jeff Cotter,senorcotter
 Jeff Frank,jeff.frank
 Jeff Justo,friffstar
+Jeff Nippard,jeffnippard
 Jeff Spawton,jayspaw
 Jeff Younker,babyhuey2k
 Jen Smith,powerliftersdiary
@@ -610,6 +619,7 @@ Jonathan Bedard,alphajonathan
 Jonathan Cayco,league_of_lifting
 Jonathan Clark,jon_mexico
 Jonathan Cotton,cottonsense
+Jonathan Davis,jdavis20345
 Jonathan Harder,gone2cold
 Jonathan Rodgers #1,jonisradical
 Jonnie Candito,canditotraininghq
@@ -631,6 +641,7 @@ Joseph Sisombath,josephsisombath
 Joseph Whittaker,whittakerpowerlifting
 Josh Banks #1,jbanks120kg
 Josh Ellis,bearjewjosh
+Josh Hancott,joshhancott
 Josh Hyaduck,joshhyaduck
 Josh Lentz,jlentz220
 Josh Morris,joshmmorris24
@@ -651,7 +662,7 @@ Julia Bringans,squatz4sushi
 Julie Brookfield,jkbambii
 Julien Comte,jucomte
 Julio Serrano,fookin_kris_jul
-Julius Maddox,maddox_irregularstrength
+Julius Maddox,irregular_strength
 Justin Bethune,justinbethune22
 Justin Byrnes,beer_bacon_deadlifts
 Justin Herder,herderjd
@@ -772,11 +783,11 @@ Louie Ortiguerra,louie_xcell
 Louise Richardson,louiserich
 LS McClain,lsm97m
 Lu Shalili,lu.zilla
-Lucas Graham,elzie870
 Lucas Martin,lucasmartinfit
 Lucian York,toobigformyshirt
 Luigi Fagiani,luigifagiani
 Luke Dreier,ldreier_bigiron
+Luke Graham,luke_kilograham
 Luke Poli,lukepoli
 Luke Richardson,lukeerichardson
 Lyndall Vile,lyndallvile_co
@@ -858,6 +869,7 @@ Michelle Lin,meeshell1n
 Mickael Cloutier,mickcloutier
 Mika Edwards,mje_8
 Mike Conley,king_con_16
+Mike Farr,silentmikke
 Mike Lackey,mlack15
 Mike McGivern,mikemcgivern
 Mike Rubinetti,ironmikerubes
@@ -899,6 +911,8 @@ Nick Israel,nickisrael_dpt
 Nick Kiger,kigerstrength
 Nick Ramey,nick_ramey
 Nick Rice,rice126
+Nick Wright,nickwrightnwb
+Nicholas Wright,nickwrightnwb
 Nicolas Bolt,nicolasbolt
 Nicole Amsler,namsler
 Nicole Balkau,nikki_b11
@@ -924,6 +938,7 @@ Pat Thompson,the.patthompson
 Patrick Morrison,manletmorrison
 Patrick Vincent Maguire,full_primal_power
 Paul Nguyen,pvn26
+Paul Revelia,paulrevelia
 Paul Vidmar,fatharrypotter
 Paulo Tanaka,paulo.tanaka
 Payal Ghosh,pghosh2
@@ -1099,6 +1114,7 @@ Steve Goggins,gogginsforce
 Steve Jellett,redbeardlifting
 Steve Johnson,forsakenwarrior
 Steve Mann,smannofsteel
+Steve Shaw,bendthebarman
 Steven Archer,bigstrengthsteve
 Steven Maradona,stevenaay
 Stian Walgermo,walgermo
@@ -1188,6 +1204,7 @@ Wei-Ling Chen,weiling14951414131
 Wendy Chan,watergirl94
 Will Hunt,nemesis_powerlifting
 William Andrews,_hunterandrews
+William Barabas,barabas_242
 William Crozier,wcroz
 Wynter Addams,wynteraddams
 Xiaver Collier,itszay__

--- a/lifter-data/social-media.csv
+++ b/lifter-data/social-media.csv
@@ -368,7 +368,6 @@ Eddie Berglund,strongeddie
 Eduard Khanjyan,eduardkhanjyan
 Eduardo Garcia,kimbo_halfslice_
 Edward Alicdan Jr,jralicdan
-Edward Koo,ed_koo
 Edward Ryckman,fast.eddie_181
 Edwin Nash,edwin_nash92
 Eli Burks,eliburks3
@@ -912,7 +911,6 @@ Nick Kiger,kigerstrength
 Nick Ramey,nick_ramey
 Nick Rice,rice126
 Nick Wright,nickwrightnwb
-Nicholas Wright,nickwrightnwb
 Nicolas Bolt,nicolasbolt
 Nicole Amsler,namsler
 Nicole Balkau,nikki_b11


### PR DESCRIPTION
Fixed Donnie Thompson and Julius Maddox. Added Dawson Windham, Luke Graham, Chris Ruden, Silent Mike (Mike Farr), Jonathan Davis, Collin Whitney, Jeff Nippard, Chris Williams, Paul Revelia, Amanda Bucci, Steve Shaw, David Lotito, Josh Hancott, William Barabas, Ed Koo, Edward Koo, Nick Wright, and Nicholas Wright. Removed Lucas Graham (did not exist).