### PR TITLE
Update social-media.csv

### DIFF
--- a/lifter-data/social-media.csv
+++ b/lifter-data/social-media.csv
@@ -811,6 +811,7 @@ Marco Galindo,marcogalindojr
 Marcos Rivera,marco.rivera14
 Marcus Morris,marcusmorris15
 Marcus Parkus,marcus.parkus
+Margarita Lisoboy,ritalisoboy
 Maria Htee,maria_htee
 Maria Ramos,maria_ramos_powerlifting
 Mariah Corke,mariahcat
@@ -1142,6 +1143,7 @@ Tarra Oravec,tarra.oravec
 Taryn Albright,waternweights
 Tasmin Campbell,tazzy_cam
 Tate Brinkley,taterstrong
+Tatyana Polstyanova,tatyana_polstyanova67
 Tavis Harris,the_iron_captain_yeg
 Taylar Stallings,taylarmade
 Taylor Atwood,t_atwood


### PR DESCRIPTION
Added Margarita Lisoboy and Tatyana Polstyanova from the top the 97 lb. wrapped for 2017 list. The smallest list ever of 16 total lifters for 2017... @sstangl 