### PR TITLE
Update results.csv

### DIFF
--- a/meet-data/rps/1615/results.csv
+++ b/meet-data/rps/1615/results.csv
@@ -134,10 +134,10 @@ MALE,AM,RAW MOD,Open,308,NH,Samuel Galletta,304.2,490,275,485,1250
 MALE,AM,RAW MOD,Open,SHW,NH,Benjamin Hartford,318.8,645,350,570,1565
 MALE,AM,RAW MOD,Open,SHW,NH,Raige Hollis,373.6,800,420,680,1900
 ,,,,,,,,,,,
-MALE,AM,RAW MOD,Open,114,MA,Jonathan Clark,,,440,,440
+MALE,AM,RAW MOD,Open,,MA,Jonathan Clark,,,440,,440
 ,,,,,,,,,,,
 MALE,PRO,RAW MOD,Open,275,ME,John Wiinikka,271.4,,340,145,485
-MALE,AM,MULTI PLY,Open,114,VT,Greg Monmaney,,,330,415,745
+MALE,AM,MULTI PLY,Open,,VT,Greg Monmaney,,,330,415,745
 ,,,,,,,,,,,
 MALE,AM,RAW MOD,Open,198,NY,Nick Moffitt,198.2,,,550,550
 MALE,AM,RAW CLAS,Mast 45-49,220,NH,Jeremy Hiltz,218.4,,,570,570


### PR DESCRIPTION
The WeightClassKg for Jonathan Clark and Greg Monmaney are incorrect, they were the only two in this meet that did not have a BodyweightKg and as such the meet's scoresheet software may have defaulted them to the -114 class (smallest male class in the RPS).
Jonathan Clark is typically around 242, and Greg Monmaney is typically 181-198, that said without actually knowing what they weighed in as I can't put anything in the WeightClassKg or BodyweightKg to replace the bad value.  For now just leave WeightClassKg blank?