### PR TITLE
Update entries.csv

### DIFF
--- a/meet-data/rps/1615/entries.csv
+++ b/meet-data/rps/1615/entries.csv
@@ -124,8 +124,8 @@ M,Wraps,Amateur Open,125,ME,Harold Spetla,123.83,294.84,185.97,294.84,775.64,SBD
 M,Wraps,Amateur Open,140,NH,Samuel Galletta,137.98,222.26,124.74,219.99,566.99,SBD,1
 M,Wraps,Amateur Open,140+,NH,Benjamin Hartford,144.61,292.57,158.76,258.55,709.87,SBD,2
 M,Wraps,Amateur Open,140+,NH,Raige Hollis,169.46,362.87,190.51,308.44,861.83,SBD,1
-M,Raw,Amateur Open,52,MA,Jonathan Clark,,,199.58,,199.58,B,1
+M,Raw,Amateur Open,,MA,Jonathan Clark,,,199.58,,199.58,B,1
 M,Raw,Pro Open,125,ME,John Wiinikka,123.1,,154.22,65.77,219.99,BD,1
-M,Multi-ply,Amateur Open,52,VT,Greg Monmaney,,,149.69,188.24,337.93,BD,1
+M,Multi-ply,Amateur Open,,VT,Greg Monmaney,,,149.69,188.24,337.93,BD,1
 M,Raw,Amateur Open,90,NY,Nick Moffitt,89.9,,,249.48,249.48,D,1
 M,Raw,Amateur Mast 45-49,100,NH,Jeremy Hiltz,99.06,,,258.55,258.55,D,1


### PR DESCRIPTION
Changed the right file this time (entries, not results).
"The WeightClassKg for Jonathan Clark and Greg Monmaney are incorrect, they were the only two in this meet that did not have a BodyweightKg and as such the meet's scoresheet software may have defaulted them to the -114 class (smallest male class in the RPS).
Jonathan Clark is typically around 242, and Greg Monmaney is typically 181-198, that said without actually knowing what they weighed in as I can't put anything in the WeightClassKg or BodyweightKg to replace the bad value. For now just leave WeightClassKg blank?"