### PR TITLE
Update entries.csv

### DIFF
--- a/meet-data/rps/1820/entries.csv
+++ b/meet-data/rps/1820/entries.csv
@@ -54,7 +54,7 @@ M,Raw,Pro Open,140,Michael George-Reichley,139.16,294.84,185.97,247.21,728.02,SB
 M,Wraps,Pro Open,140,Jesse Wahdan,130.27,265.35,183.7,274.42,723.48,SBD,3
 M,Wraps,Elite Open,140,Matthew Wilk,130.36,324.32,201.85,307.31,833.48,SBD,1
 M,Wraps,Pro Open,140,Michel Welton,137.71,328.85,204.12,324.32,857.29,SBD,2
-M,Wraps,Pro Open,140,Chris Weist,132.99,328.85,199.58,412.77,941.2,SBD,1
+M,Wraps,Pro Open,140,Chris Weist,132.99,328.85,199.58,415.04,943.47,SBD,1
 M,Wraps,Amateur Open,140+,Jason Frawley,155.22,308.44,188.24,310.71,807.39,SBD,1
 M,Wraps,Pro Open,140+,William Richards,147.78,331.12,229.06,347,907.18,SBD,1
 F,Raw,Amateur Master 45-49,100,Kathryn Welcheck,98.52,,54.43,,54.43,B,1


### PR DESCRIPTION
After some confusion on Chris's best deadlift attempt, RPS changed the result on the results page to 915 lb http://meets.revolutionpowerlifting.com/results/2018-meet-results/5th-set-black/