### PR TITLE
Update name-corrections.dat

### DIFF
--- a/lifter-data/name-corrections.dat
+++ b/lifter-data/name-corrections.dat
@@ -5084,3 +5084,9 @@ LB Arguelles,L.B. Arguelles
 Barzeen Vaziri,Barzeen Viziri
 Timothy Mercer,Tim Mercer
 Marianna Gasparyan,Marianna Gasparian
+Lauren Green,Lauren Hannon
+Nick Kroussos,Nick Krousos
+Alby Owens,Albert Owens
+Mathew Procak,Mathew Procack
+Danny Saelam Barrett,Danny Barrett
+Steve Jellett,Steve Jellet


### PR DESCRIPTION
Fixing some incorrect names noticed in GPC Aus 2018 Nats, also, Lauren Hannon recently married and is now Lauren Green